### PR TITLE
Optimisations for common cases

### DIFF
--- a/src/_spead/include/spead_packet.h
+++ b/src/_spead/include/spead_packet.h
@@ -137,6 +137,8 @@ typedef struct {
     int is_valid;
     int64_t heap_cnt;
     int64_t heap_len;
+    // Total bytes of payload received (possibly including duplicated packets)
+    int64_t received_len;
     int has_all_packets;
     SpeadPacket *head_pkt;
     SpeadPacket *last_pkt;

--- a/src/spead.py
+++ b/src/spead.py
@@ -11,6 +11,7 @@ import socket
 import numpy
 import logging
 import time
+from collections import deque
 from numpy.lib.utils import safe_eval
 import _spead
 
@@ -741,9 +742,9 @@ class TransportUDPtx:
 class TransportUDPrx(_spead.BufferSocket):
     def __init__(self, port, pkt_count=128, buffer_size=0):
         _spead.BufferSocket.__init__(self, pkt_count)
-        self.pkts = []
+        self.pkts = deque()
         def callback(pkt):
-            self.pkts.insert(0, pkt)
+            self.pkts.appendleft(pkt)
         self.set_callback(callback)
         self.start(port, buffer_size)
 


### PR DESCRIPTION
There are four optimisations:
- spead_add_packet is made O(1) for a packet that arrives in-order
  (payload_off is higher than other packets already processed)
- spead_got_all_packets is made O(1) in the absense of duplicated
  packets (and still fast overall if few packets are duplicated)
- spead_heap_finalize copies chunks of memory with memcpy, instead of
  looking for one byte at a time
- The packet buffer in the Python code is changed from a Python list to
  a deque, to avoid O(N) insertions.
