### PR TITLE
Add rate= option to TransportUDPtx

### DIFF
--- a/src/spead.py
+++ b/src/spead.py
@@ -747,7 +747,6 @@ class TransportUDPtx:
         self._tx_ip_port = (ip, port)
         self._rate = rate
         self._last_time = time.time()
-        self._carry_wait = 0.0
 
     def write(self, data):
         self._udp_out.sendto(data, self._tx_ip_port)

--- a/tests/spead_example03.py
+++ b/tests/spead_example03.py
@@ -3,7 +3,7 @@ import spead64_48 as spead
 import logging
 import sys
 
-logging.basicConfig(level=logging.INFO)
+#logging.basicConfig(level=logging.INFO)
 PORT = 8888
 
 
@@ -28,7 +28,7 @@ def receive():
 
 def transmit():
     print 'TX: Initializing...'
-    tx = spead.Transmitter(spead.TransportUDPtx('127.0.0.1', PORT))
+    tx = spead.Transmitter(spead.TransportUDPtx('127.0.0.1', PORT, rate=1e9))
     ig = spead.ItemGroup()
 
     ig.add_item(name='Var1', description='Description for Var1',
@@ -38,9 +38,9 @@ def transmit():
     ig['Var1'] = (4,5,6)
     tx.send_heap(ig.get_heap())
 
+    data = numpy.arange(100000*4000).astype(numpy.uint32); data.shape = (100000,4000)
     ig.add_item(name='Var2', description='Description for Var2',
-        shape=[100,100], fmt=spead.mkfmt(('u',32)))
-    data = numpy.arange(100*100); data.shape = (100,100)
+        shape=[100000,4000], ndarray=data)
     ig['Var2'] = data
     tx.send_heap(ig.get_heap())
 


### PR DESCRIPTION
This allows transmission to be slowed down to avoid overloading the network and causing dropped packets.

I've tested this using a packet counter to monitor the transmission rate. The heuristic of not bothering to sleep for less than 0.01s was necessary to make it get reasonably close to the desired rate (otherwise you tend to sleep a whole timeslice even if you asked for less). It will make the transmission a little bursty, so we may need to tune it later.
